### PR TITLE
Add Azure OpenAI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The app will be up and running at http://localhost:5173. Note that you can't dev
 - **I'm running into an error when setting up the backend. How can I fix it?** [Try this](https://github.com/abi/screenshot-to-code/issues/3#issuecomment-1814777959). If that still doesn't work, open an issue.
 - **How do I get an OpenAI API key?** See https://github.com/abi/screenshot-to-code/blob/main/Troubleshooting.md
 - **How can I configure an OpenAI proxy?** - If you're not able to access the OpenAI API directly (due to e.g. country restrictions), you can try a VPN or you can configure the OpenAI base URL to use a proxy: Set OPENAI_BASE_URL in the `backend/.env` or directly in the UI in the settings dialog. Make sure the URL has "v1" in the path so it should look like this: `https://xxx.xxxxx.xxx/v1`
+- **Can I use Azure OpenAI?** - Yes! Set `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT` and optionally `AZURE_OPENAI_API_VERSION` in `backend/.env` or in the settings dialog.
 - **How can I update the backend host that my front-end connects to?** - Configure VITE_HTTP_BACKEND_URL and VITE_WS_BACKEND_URL in front/.env.local For example, set VITE_HTTP_BACKEND_URL=http://124.10.20.1:7001
 - **Seeing UTF-8 errors when running the backend?** - On windows, open the .env file with notepad++, then go to Encoding and select UTF-8.
 - **How can I provide feedback?** For feedback, feature requests and bug reports, open an issue or ping me on [Twitter](https://twitter.com/_abi_).

--- a/backend/config.py
+++ b/backend/config.py
@@ -10,6 +10,12 @@ OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", None)
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", None)
 GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY", None)
 OPENAI_BASE_URL = os.environ.get("OPENAI_BASE_URL", None)
+AZURE_OPENAI_API_KEY = os.environ.get("AZURE_OPENAI_API_KEY", None)
+AZURE_OPENAI_ENDPOINT = os.environ.get("AZURE_OPENAI_ENDPOINT", None)
+AZURE_OPENAI_DEPLOYMENT = os.environ.get("AZURE_OPENAI_DEPLOYMENT", None)
+AZURE_OPENAI_API_VERSION = os.environ.get(
+    "AZURE_OPENAI_API_VERSION", "2023-07-01-preview"
+)
 
 # Image generation (optional)
 REPLICATE_API_KEY = os.environ.get("REPLICATE_API_KEY", None)

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,13 +1,15 @@
 from .claude import stream_claude_response, stream_claude_response_native
 from .openai_client import stream_openai_response
+from .azure_openai_client import stream_azure_openai_response
 from .gemini import stream_gemini_response
 from llm import Completion
 
 # Re-export the functions for backward compatibility
 __all__ = [
-    "stream_claude_response", 
+    "stream_claude_response",
     "stream_claude_response_native",
     "stream_openai_response",
+    "stream_azure_openai_response",
     "stream_gemini_response",
     "Completion"
 ]

--- a/backend/models/azure_openai_client.py
+++ b/backend/models/azure_openai_client.py
@@ -1,0 +1,48 @@
+import time
+from typing import Awaitable, Callable, List
+from openai import AsyncAzureOpenAI
+from openai.types.chat import ChatCompletionMessageParam, ChatCompletionChunk
+from llm import Completion
+
+
+async def stream_azure_openai_response(
+    messages: List[ChatCompletionMessageParam],
+    api_key: str,
+    endpoint: str,
+    deployment: str,
+    api_version: str,
+    callback: Callable[[str], Awaitable[None]],
+) -> Completion:
+    """Stream completions from an Azure OpenAI deployment."""
+    start_time = time.time()
+    client = AsyncAzureOpenAI(
+        api_key=api_key,
+        azure_endpoint=endpoint,
+        api_version=api_version,
+    )
+
+    params = {
+        "model": deployment,
+        "messages": messages,
+        "temperature": 0,
+        "stream": True,
+        "timeout": 600,
+    }
+
+    stream = await client.chat.completions.create(**params)  # type: ignore
+    full_response = ""
+    async for chunk in stream:  # type: ignore
+        assert isinstance(chunk, ChatCompletionChunk)
+        if (
+            chunk.choices
+            and len(chunk.choices) > 0
+            and chunk.choices[0].delta
+            and chunk.choices[0].delta.content
+        ):
+            content = chunk.choices[0].delta.content or ""
+            full_response += content
+            await callback(content)
+
+    await client.close()
+    completion_time = time.time() - start_time
+    return {"duration": completion_time, "code": full_response}


### PR DESCRIPTION
## Summary
- support Azure OpenAI with new `stream_azure_openai_response`
- expose Azure environment variables
- allow Azure parameters in generate-code route
- handle Azure in evals
- document new config option

## Testing
- `poetry run pyright` *(fails: Import errors)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6842ab7262a48321a56d3d4dddb420c1