### PR TITLE
Add Azure OpenAI settings

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -63,6 +63,10 @@ function App() {
     {
       openAiApiKey: null,
       openAiBaseURL: null,
+      azureOpenAiApiKey: null,
+      azureOpenAiEndpoint: null,
+      azureOpenAiDeployment: null,
+      azureOpenAiApiVersion: null,
       anthropicApiKey: null,
       screenshotOneApiKey: null,
       isImageGenerationEnabled: true,

--- a/frontend/src/components/settings/SettingsDialog.tsx
+++ b/frontend/src/components/settings/SettingsDialog.tsx
@@ -111,6 +111,82 @@ function SettingsDialog({ settings, setSettings }: Props) {
           )}
 
           <div>
+            <Label htmlFor="azure-openai-api-key">
+              <div>Azure OpenAI API key</div>
+              <div className="font-light mt-1 text-xs leading-relaxed">
+                Only stored in your browser. Never stored on servers. Overrides
+                your .env config.
+              </div>
+            </Label>
+
+            <Input
+              id="azure-openai-api-key"
+              placeholder="Azure OpenAI API key"
+              value={settings.azureOpenAiApiKey || ""}
+              onChange={(e) =>
+                setSettings((s) => ({
+                  ...s,
+                  azureOpenAiApiKey: e.target.value,
+                }))
+              }
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="azure-openai-endpoint">
+              <div>Azure OpenAI Endpoint</div>
+            </Label>
+
+            <Input
+              id="azure-openai-endpoint"
+              placeholder="Azure OpenAI Endpoint"
+              value={settings.azureOpenAiEndpoint || ""}
+              onChange={(e) =>
+                setSettings((s) => ({
+                  ...s,
+                  azureOpenAiEndpoint: e.target.value,
+                }))
+              }
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="azure-openai-deployment">
+              <div>Azure OpenAI Deployment</div>
+            </Label>
+
+            <Input
+              id="azure-openai-deployment"
+              placeholder="Azure OpenAI Deployment"
+              value={settings.azureOpenAiDeployment || ""}
+              onChange={(e) =>
+                setSettings((s) => ({
+                  ...s,
+                  azureOpenAiDeployment: e.target.value,
+                }))
+              }
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="azure-openai-api-version">
+              <div>Azure OpenAI API Version (optional)</div>
+            </Label>
+
+            <Input
+              id="azure-openai-api-version"
+              placeholder="Azure OpenAI API Version"
+              value={settings.azureOpenAiApiVersion || ""}
+              onChange={(e) =>
+                setSettings((s) => ({
+                  ...s,
+                  azureOpenAiApiVersion: e.target.value,
+                }))
+              }
+            />
+          </div>
+
+          <div>
             <Label htmlFor="anthropic-api-key">
               <div>Anthropic API key</div>
               <div className="font-light mt-1 text-xs leading-relaxed">

--- a/frontend/src/tests/qa.test.ts
+++ b/frontend/src/tests/qa.test.ts
@@ -164,6 +164,10 @@ class App {
     const setting = {
       openAiApiKey: null,
       openAiBaseURL: null,
+      azureOpenAiApiKey: null,
+      azureOpenAiEndpoint: null,
+      azureOpenAiDeployment: null,
+      azureOpenAiApiVersion: null,
       screenshotOneApiKey: process.env.TEST_SCREENSHOTONE_API_KEY,
       isImageGenerationEnabled: true,
       editorTheme: "cobalt",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -9,6 +9,10 @@ export enum EditorTheme {
 export interface Settings {
   openAiApiKey: string | null;
   openAiBaseURL: string | null;
+  azureOpenAiApiKey: string | null;
+  azureOpenAiEndpoint: string | null;
+  azureOpenAiDeployment: string | null;
+  azureOpenAiApiVersion: string | null;
   screenshotOneApiKey: string | null;
   isImageGenerationEnabled: boolean;
   editorTheme: EditorTheme;


### PR DESCRIPTION
## Summary
- add Azure OpenAI fields to Settings type and dialog
- persist Azure OpenAI fields in state defaults and tests

## Testing
- `yarn test` *(fails: package not installed)*
- `pytest` *(fails: openai module missing)*

------
https://chatgpt.com/codex/tasks/task_e_684324782fac8321aab3246f7cd0fa4f